### PR TITLE
Feat/pre commit build

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "postBuild": "node dist/cjs/postBuild.js",
     "clean": "bebbi-scripts clean",
     "validate": "bebbi-scripts validate",
+    "pre-commit": "bebbi-scripts pre-commit",
     "postinstall": "husky install",
     "prepack": "pinst --disable",
     "postpack": "pinst --enable"

--- a/package.json
+++ b/package.json
@@ -87,7 +87,9 @@
     "postBuild": "node dist/cjs/postBuild.js",
     "clean": "bebbi-scripts clean",
     "validate": "bebbi-scripts validate",
-    "prepare": "husky install"
+    "postinstall": "husky install",
+    "prepack": "pinst --disable",
+    "postpack": "pinst --enable"
   },
   "author": "Stefan Baumann <stefan.baumann@gigmade.com>",
   "homepage": "www.gigmade.com",


### PR DESCRIPTION
- Fix husky hooks not running because Yarn doesn't support prepare. Please see https://typicode.github.io/husky/how-to.html#manual-setup on how to manually set up for yarn (relevant for husky 8; docs only for the latest husky 9).
- `bebbi-scripts` already supports `yarn build` if it's there, else runs `yarn validate` after linting on pre-commit

It would be a good idea to bump husky to the latest version (9).